### PR TITLE
add initiate account refresh method to the API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.idea
+node_modules
+/.idea

--- a/index.js
+++ b/index.js
@@ -55,6 +55,8 @@ function _jsonify(promise) {
     return promise.then(function(body) {
         if (~body.indexOf("Session has expired."))
             throw new Error("Session has expired");
+        if (~body.indexOf("<response><empty/></response>"))
+            return { refreshInitiated: true };
 
         try {
             return JSON.parse(body);
@@ -251,6 +253,14 @@ PepperMint.prototype.deleteTransaction = function(transactionId) {
     });
 };
 
+/**
+ * Refresh account FI Data
+ */
+PepperMint.prototype.initiateAccountRefresh = function(){
+    return this._form('refreshFILogins.xevent', {
+        token: this.token
+    });
+};
 
 
 /*

--- a/index.js
+++ b/index.js
@@ -56,7 +56,7 @@ function _jsonify(promise) {
         if (~body.indexOf("Session has expired."))
             throw new Error("Session has expired");
         if (~body.indexOf("<response><empty/></response>"))
-            return { refreshInitiated: true };
+            return { success: true };
 
         try {
             return JSON.parse(body);


### PR DESCRIPTION
I previously used the python api that this repo is based on and I used the account refresh method often. If possible it would be awesome to implement. I added it into my fork but it would be great to have a working fix in the main pepper-mint. 