### PR TITLE
Use 'txnedit' task instead of 'simpleEdit' for updating transactions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules
 /.idea
 test/config.json
+test/integration-config.json
 test/test2.js
 
 # Created by https://www.gitignore.io/api/node

--- a/index.js
+++ b/index.js
@@ -647,7 +647,7 @@ PepperMint.prototype.editTransaction = function(args) {
       , categoryTypeFilter: 'null'
       , date: stringifyDate(args.date)
       , merchant: args.merchant
-      , task: 'simpleEdit'
+      , task: 'txnedit'
       , txnId: args.id
 
       , token: this.token

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -7,26 +7,27 @@ try {
   var config = require('./integration-config.json');
 } catch (e) {
   // no config; don't run tests
-  process.exit()
 }
 
-describe('pepper-mint', function () {
-  describe('handles editing transactions', function () {
-    it('verifies fields have changed after editing', async function () {
-      this.timeout(30000);
-      let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid)
-      await createTransaction(mint)
-      let transactions = await getTransactions(mint)
+if (config) {
+  describe('pepper-mint', function () {
+    describe('handles editing transactions', function () {
+      it('verifies fields have changed after editing', async function () {
+        this.timeout(30000);
+        let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid)
+        await createTransaction(mint)
+        let transactions = await getTransactions(mint)
 
-      await editTransaction(mint, transactions)
-      let newTnx = await getTransactions(mint)
+        await editTransaction(mint, transactions)
+        let newTnx = await getTransactions(mint)
 
-      await deleteTransaction(mint, newTnx)
+        await deleteTransaction(mint, newTnx)
 
-      await doAssertions(newTnx)
-    })
+        await doAssertions(newTnx)
+      })
+    });
   });
-});
+}
 
 function doAssertions(transaction) {
   transaction[0].merchant.should.equal("New Test Merchant Name")

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1,5 +1,5 @@
 let chai = require('chai');
-let PepperMint = require('../index')
+let PepperMint = require('../index');
 
 chai.should();
 

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -67,6 +67,7 @@ function doAssertions(updatedTransaction, originalTransaction) {
   updatedTransaction.category.should.equal(originalTransaction.category)
   updatedTransaction.categoryId.should.equal(originalTransaction.categoryId)
   updatedTransaction.date.should.equal(originalTransaction.date)
+  updatedTransaction.note.should.equal(originalTransaction.note)
 }
 
 function doAssertionsWithUpdates(updatedTransaction, transactionUpdates) {

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -1,0 +1,72 @@
+let chai = require('chai');
+let PepperMint = require('../index')
+
+chai.should();
+
+try {
+  var config = require('./integration-config.json');
+} catch (e) {
+  // no config; don't run tests
+  process.exit()
+}
+
+describe('pepper-mint', function () {
+  describe('handles editing transactions', function () {
+    it('verifies fields have changed after editing', async function () {
+      let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid)
+      await createTransaction(mint)
+      let transactions = await getTransactions(mint)
+
+      await editTransaction(mint, transactions)
+      let newTnx = await getTransactions(mint)
+
+      await deleteTransaction(mint, newTnx)
+
+      await doAssertions(newTnx)
+    })
+  });
+});
+
+function doAssertions(transaction) {
+  transaction[0].merchant.should.equal("New Test Merchant Name")
+  transaction[0].category.should.equal("Vacation")
+  transaction[0].categoryId.should.equal(1504)
+  transaction[0].date.should.equal("May 5")
+  return transaction
+}
+
+function createTransaction(mint) {
+  let createRequest = {
+    amount: 1.23,
+    date: "05/04/2018",
+    merchant: "Test Merchant Name",
+    note: "This is a test transaction"
+  }
+  return mint.createTransaction(createRequest)
+}
+
+function getTransactions(mint) {
+  let getTransactionsRequest = {
+    query: [
+      "Test Merchant Name"
+    ],
+    startDate: new Date(2018, 4),
+    endDate: new Date(2018, 6)
+  }
+  return mint.getTransactions(getTransactionsRequest)
+}
+
+function editTransaction(mint, tnx) {
+  let editTransactionRequest = {
+    id: tnx[0].id,
+    merchant: "New Test Merchant Name",
+    category: "Vacation",
+    categoryId: 1504,
+    date: "05/05/2018"
+  }
+  return mint.editTransaction(editTransactionRequest)
+}
+
+function deleteTransaction(mint, transactions) {
+  return mint.deleteTransaction(transactions[0].id)
+}

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -67,7 +67,6 @@ function doAssertions(updatedTransaction, originalTransaction) {
   updatedTransaction.category.should.equal(originalTransaction.category)
   updatedTransaction.categoryId.should.equal(originalTransaction.categoryId)
   updatedTransaction.date.should.equal(originalTransaction.date)
-  return updatedTransaction
 }
 
 function doAssertionsWithUpdates(updatedTransaction, transactionUpdates) {
@@ -75,7 +74,6 @@ function doAssertionsWithUpdates(updatedTransaction, transactionUpdates) {
   updatedTransaction.category.should.equal(transactionUpdates.category)
   updatedTransaction.categoryId.should.equal(transactionUpdates.categoryId)
   updatedTransaction.date.should.equal(formatDate(transactionUpdates.date))
-  return updatedTransaction
 }
 
 function createTransaction(mint) {

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -4,141 +4,141 @@ let PepperMint = require('../index');
 chai.should();
 
 try {
-  var config = require('./integration-config.json');
+    var config = require('./integration-config.json');
 } catch (e) {
-  // no config; don't run tests
+    // no config; don't run tests
 }
 
 if (config) {
-  describe('pepper-mint', function() {
-    describe('handles editing transactions', function() {
-      it('verifies fields have changed after editing', async function() {
-        this.timeout(30000);
-        let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid);
-        await createTransaction(mint);
-        let originalTransaction = (await getTransactions(mint))[0];
+    describe('pepper-mint', function() {
+        describe('handles editing transactions', function() {
+            it('verifies fields have changed after editing', async function() {
+                this.timeout(30000);
+                let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid);
+                await createTransaction(mint);
+                let originalTransaction = (await getTransactions(mint))[0];
 
-        let transactionUpdates = getTransactionUpdates(originalTransaction);
-        await editTransactionWithUpdates(mint, transactionUpdates);
-        let updatedTransaction = (await getTransactions(mint))[0];
+                let transactionUpdates = getTransactionUpdates(originalTransaction);
+                await editTransactionWithUpdates(mint, transactionUpdates);
+                let updatedTransaction = (await getTransactions(mint))[0];
 
-        await deleteTransaction(mint, updatedTransaction);
+                await deleteTransaction(mint, updatedTransaction);
 
-        await doAssertionsWithUpdates(updatedTransaction, transactionUpdates);
-      });
-      it('verifies undefined fields when updating will not be cleared after editing', async function() {
-        this.timeout(30000);
-        let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid);
-        await createTransaction(mint);
-        let originalTransaction = (await getTransactions(mint))[0];
+                await doAssertionsWithUpdates(updatedTransaction, transactionUpdates);
+            });
+            it('verifies undefined fields when updating will not be cleared after editing', async function() {
+                this.timeout(30000);
+                let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid);
+                await createTransaction(mint);
+                let originalTransaction = (await getTransactions(mint))[0];
 
-        let transactionUpdates = getTransactionUpdates(originalTransaction);
-        setAllOptionalFieldsUndefined(transactionUpdates);
+                let transactionUpdates = getTransactionUpdates(originalTransaction);
+                setAllOptionalFieldsUndefined(transactionUpdates);
 
-        await editTransactionWithUpdates(mint, transactionUpdates);
-        let updatedTransaction = (await getTransactions(mint))[0];
+                await editTransactionWithUpdates(mint, transactionUpdates);
+                let updatedTransaction = (await getTransactions(mint))[0];
 
-        await deleteTransaction(mint, updatedTransaction);
+                await deleteTransaction(mint, updatedTransaction);
 
-        await doAssertions(updatedTransaction, originalTransaction);
-      });
-      it('verifies empty fields when updating will not be cleared after editing', async function() {
-        this.timeout(30000);
-        let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid);
-        await createTransaction(mint);
-        let originalTransaction = (await getTransactions(mint))[0];
+                await doAssertions(updatedTransaction, originalTransaction);
+            });
+            it('verifies empty fields when updating will not be cleared after editing', async function() {
+                this.timeout(30000);
+                let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid);
+                await createTransaction(mint);
+                let originalTransaction = (await getTransactions(mint))[0];
 
-        let transactionUpdates = getTransactionUpdates(originalTransaction);
-        setAllFieldsEmpty(transactionUpdates);
+                let transactionUpdates = getTransactionUpdates(originalTransaction);
+                setAllFieldsEmpty(transactionUpdates);
 
-        await editTransactionWithUpdates(mint, transactionUpdates);
-        let updatedTransaction = (await getTransactions(mint))[0];
+                await editTransactionWithUpdates(mint, transactionUpdates);
+                let updatedTransaction = (await getTransactions(mint))[0];
 
-        await deleteTransaction(mint, updatedTransaction);
+                await deleteTransaction(mint, updatedTransaction);
 
-        await doAssertions(updatedTransaction, originalTransaction);
-      })
+                await doAssertions(updatedTransaction, originalTransaction);
+            })
+        });
     });
-  });
 }
 
 function doAssertions(updatedTransaction, originalTransaction) {
-  updatedTransaction.merchant.should.equal(originalTransaction.merchant);
-  updatedTransaction.category.should.equal(originalTransaction.category);
-  updatedTransaction.categoryId.should.equal(originalTransaction.categoryId);
-  updatedTransaction.date.should.equal(originalTransaction.date);
-  updatedTransaction.note.should.equal(originalTransaction.note);
+    updatedTransaction.merchant.should.equal(originalTransaction.merchant);
+    updatedTransaction.category.should.equal(originalTransaction.category);
+    updatedTransaction.categoryId.should.equal(originalTransaction.categoryId);
+    updatedTransaction.date.should.equal(originalTransaction.date);
+    updatedTransaction.note.should.equal(originalTransaction.note);
 }
 
 function doAssertionsWithUpdates(updatedTransaction, transactionUpdates) {
-  updatedTransaction.merchant.should.equal(transactionUpdates.merchant);
-  updatedTransaction.category.should.equal(transactionUpdates.category);
-  updatedTransaction.categoryId.should.equal(transactionUpdates.categoryId);
-  updatedTransaction.date.should.equal(formatDate(transactionUpdates.date));
+    updatedTransaction.merchant.should.equal(transactionUpdates.merchant);
+    updatedTransaction.category.should.equal(transactionUpdates.category);
+    updatedTransaction.categoryId.should.equal(transactionUpdates.categoryId);
+    updatedTransaction.date.should.equal(formatDate(transactionUpdates.date));
 }
 
 function createTransaction(mint) {
-  let createRequest = {
-    amount: 1.23,
-    date: "05/04/2010",
-    merchant: "Test Merchant Name",
-    note: "This is a test transaction"
-  };
-  return mint.createTransaction(createRequest);
+    let createRequest = {
+        amount: 1.23,
+        date: "05/04/2010",
+        merchant: "Test Merchant Name",
+        note: "This is a test transaction"
+    };
+    return mint.createTransaction(createRequest);
 }
 
 function getTransactions(mint) {
-  let getTransactionsRequest = {
-    query: [
-      "Test Merchant Name"
-    ],
-    startDate: new Date(2010, 4),
-    endDate: new Date(2010, 6)
-  };
-  return mint.getTransactions(getTransactionsRequest);
+    let getTransactionsRequest = {
+        query: [
+            "Test Merchant Name"
+        ],
+        startDate: new Date(2010, 4),
+        endDate: new Date(2010, 6)
+    };
+    return mint.getTransactions(getTransactionsRequest);
 }
 
 function editTransactionWithUpdates(mint, updates) {
-  return mint.editTransaction(updates);
+    return mint.editTransaction(updates);
 }
 
 function getTransactionUpdates(originalTransaction) {
-  return {
-    id: originalTransaction.id,
-    merchant: "New Test Merchant Name",
-    category: "Vacation",
-    categoryId: 1504,
-    date: "05/05/2010"
-  };
+    return {
+        id: originalTransaction.id,
+        merchant: "New Test Merchant Name",
+        category: "Vacation",
+        categoryId: 1504,
+        date: "05/05/2010"
+    };
 }
 
 function deleteTransaction(mint, transactions) {
-  return mint.deleteTransaction(transactions.id)
+    return mint.deleteTransaction(transactions.id)
 }
 
 function setAllFieldsEmpty(transactionUpdates) {
-  transactionUpdates.merchant = "";
-  transactionUpdates.category = "";
-  transactionUpdates.categoryId = "";
-  transactionUpdates.date = "";
+    transactionUpdates.merchant = "";
+    transactionUpdates.category = "";
+    transactionUpdates.categoryId = "";
+    transactionUpdates.date = "";
 }
 
 function setAllOptionalFieldsUndefined(transactionUpdates) {
-  transactionUpdates.merchant = undefined;
-  transactionUpdates.category = undefined;
-  transactionUpdates.categoryId = undefined;
-  // Date is a required field
-  transactionUpdates.date = "";
+    transactionUpdates.merchant = undefined;
+    transactionUpdates.category = undefined;
+    transactionUpdates.categoryId = undefined;
+    // Date is a required field
+    transactionUpdates.date = "";
 }
 
 function formatDate(currentYearStyledDate) {
-  let date = new Date(currentYearStyledDate);
-  let year = date.getFullYear().toString().slice(2);
-  let month = padLeadingZero(date.getMonth() + 1);
-  let day = padLeadingZero(date.getDate());
-  return `${month}/${day}/${year}`
+    let date = new Date(currentYearStyledDate);
+    let year = date.getFullYear().toString().slice(2);
+    let month = padLeadingZero(date.getMonth() + 1);
+    let day = padLeadingZero(date.getDate());
+    return `${month}/${day}/${year}`
 }
 
 function padLeadingZero(number) {
-  return `0${number.toString()}`.slice(-2);
+    return `0${number.toString()}`.slice(-2);
 }

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -14,67 +14,67 @@ if (config) {
     describe('handles editing transactions', function () {
       it('verifies fields have changed after editing', async function () {
         this.timeout(30000);
-        let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid)
-        await createTransaction(mint)
-        let originalTransaction = (await getTransactions(mint))[0]
+        let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid);
+        await createTransaction(mint);
+        let originalTransaction = (await getTransactions(mint))[0];
 
-        let transactionUpdates = getTransactionUpdates(originalTransaction)
-        await editTransactionWithUpdates(mint, transactionUpdates)
-        let updatedTransaction = (await getTransactions(mint))[0]
+        let transactionUpdates = getTransactionUpdates(originalTransaction);
+        await editTransactionWithUpdates(mint, transactionUpdates);
+        let updatedTransaction = (await getTransactions(mint))[0];
 
-        await deleteTransaction(mint, updatedTransaction)
+        await deleteTransaction(mint, updatedTransaction);
 
-        await doAssertionsWithUpdates(updatedTransaction, transactionUpdates)
-      })
+        await doAssertionsWithUpdates(updatedTransaction, transactionUpdates);
+      });
       it('verifies undefined fields when updating will not be cleared after editing', async function () {
         this.timeout(30000);
-        let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid)
-        await createTransaction(mint)
-        let originalTransaction = (await getTransactions(mint))[0]
+        let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid);
+        await createTransaction(mint);
+        let originalTransaction = (await getTransactions(mint))[0];
 
-        let transactionUpdates = getTransactionUpdates(originalTransaction)
+        let transactionUpdates = getTransactionUpdates(originalTransaction);
         setAllOptionalFieldsUndefined(transactionUpdates);
 
-        await editTransactionWithUpdates(mint, transactionUpdates)
-        let updatedTransaction = (await getTransactions(mint))[0]
+        await editTransactionWithUpdates(mint, transactionUpdates);
+        let updatedTransaction = (await getTransactions(mint))[0];
 
-        await deleteTransaction(mint, updatedTransaction)
+        await deleteTransaction(mint, updatedTransaction);
 
-        await doAssertions(updatedTransaction, originalTransaction)
-      })
+        await doAssertions(updatedTransaction, originalTransaction);
+      });
       it('verifies empty fields when updating will not be cleared after editing', async function () {
         this.timeout(30000);
-        let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid)
-        await createTransaction(mint)
-        let originalTransaction = (await getTransactions(mint))[0]
+        let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid);
+        await createTransaction(mint);
+        let originalTransaction = (await getTransactions(mint))[0];
 
-        let transactionUpdates = getTransactionUpdates(originalTransaction)
+        let transactionUpdates = getTransactionUpdates(originalTransaction);
         setAllFieldsEmpty(transactionUpdates);
 
-        await editTransactionWithUpdates(mint, transactionUpdates)
-        let updatedTransaction = (await getTransactions(mint))[0]
+        await editTransactionWithUpdates(mint, transactionUpdates);
+        let updatedTransaction = (await getTransactions(mint))[0];
 
-        await deleteTransaction(mint, updatedTransaction)
+        await deleteTransaction(mint, updatedTransaction);
 
-        await doAssertions(updatedTransaction, originalTransaction)
+        await doAssertions(updatedTransaction, originalTransaction);
       })
     });
   });
 }
 
 function doAssertions(updatedTransaction, originalTransaction) {
-  updatedTransaction.merchant.should.equal(originalTransaction.merchant)
-  updatedTransaction.category.should.equal(originalTransaction.category)
-  updatedTransaction.categoryId.should.equal(originalTransaction.categoryId)
-  updatedTransaction.date.should.equal(originalTransaction.date)
-  updatedTransaction.note.should.equal(originalTransaction.note)
+  updatedTransaction.merchant.should.equal(originalTransaction.merchant);
+  updatedTransaction.category.should.equal(originalTransaction.category);
+  updatedTransaction.categoryId.should.equal(originalTransaction.categoryId);
+  updatedTransaction.date.should.equal(originalTransaction.date);
+  updatedTransaction.note.should.equal(originalTransaction.note);
 }
 
 function doAssertionsWithUpdates(updatedTransaction, transactionUpdates) {
-  updatedTransaction.merchant.should.equal(transactionUpdates.merchant)
-  updatedTransaction.category.should.equal(transactionUpdates.category)
-  updatedTransaction.categoryId.should.equal(transactionUpdates.categoryId)
-  updatedTransaction.date.should.equal(formatDate(transactionUpdates.date))
+  updatedTransaction.merchant.should.equal(transactionUpdates.merchant);
+  updatedTransaction.category.should.equal(transactionUpdates.category);
+  updatedTransaction.categoryId.should.equal(transactionUpdates.categoryId);
+  updatedTransaction.date.should.equal(formatDate(transactionUpdates.date));
 }
 
 function createTransaction(mint) {
@@ -83,8 +83,8 @@ function createTransaction(mint) {
     date: "05/04/2010",
     merchant: "Test Merchant Name",
     note: "This is a test transaction"
-  }
-  return mint.createTransaction(createRequest)
+  };
+  return mint.createTransaction(createRequest);
 }
 
 function getTransactions(mint) {
@@ -94,12 +94,12 @@ function getTransactions(mint) {
     ],
     startDate: new Date(2010, 4),
     endDate: new Date(2010, 6)
-  }
-  return mint.getTransactions(getTransactionsRequest)
+  };
+  return mint.getTransactions(getTransactionsRequest);
 }
 
 function editTransactionWithUpdates(mint, updates) {
-  return mint.editTransaction(updates)
+  return mint.editTransaction(updates);
 }
 
 function getTransactionUpdates(originalTransaction) {
@@ -117,28 +117,28 @@ function deleteTransaction(mint, transactions) {
 }
 
 function setAllFieldsEmpty(transactionUpdates) {
-  transactionUpdates.merchant = ""
-  transactionUpdates.category = ""
-  transactionUpdates.categoryId = ""
-  transactionUpdates.date = ""
+  transactionUpdates.merchant = "";
+  transactionUpdates.category = "";
+  transactionUpdates.categoryId = "";
+  transactionUpdates.date = "";
 }
 
 function setAllOptionalFieldsUndefined(transactionUpdates) {
-  transactionUpdates.merchant = undefined
-  transactionUpdates.category = undefined
-  transactionUpdates.categoryId = undefined
+  transactionUpdates.merchant = undefined;
+  transactionUpdates.category = undefined;
+  transactionUpdates.categoryId = undefined;
   // Date is a required field
-  transactionUpdates.date = ""
+  transactionUpdates.date = "";
 }
 
 function formatDate(currentYearStyledDate) {
-  let date = new Date(currentYearStyledDate)
-  let year = date.getFullYear().toString().slice(2)
-  let month = padLeadingZero(date.getMonth() + 1)
-  let day = padLeadingZero(date.getDate())
+  let date = new Date(currentYearStyledDate);
+  let year = date.getFullYear().toString().slice(2);
+  let month = padLeadingZero(date.getMonth() + 1);
+  let day = padLeadingZero(date.getDate());
   return `${month}/${day}/${year}`
 }
 
 function padLeadingZero(number) {
-  return `0${number.toString()}`.slice(-2)
+  return `0${number.toString()}`.slice(-2);
 }

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -26,15 +26,14 @@ if (config) {
 
         await doAssertionsWithUpdates(updatedTransaction, transactionUpdates)
       })
-      // TODO: Ignored due to bug in PepperMint.editTransaction which requires you to pass in a date.
-      xit('verifies undefined fields when updating will not be cleared after editing', async function () {
+      it('verifies undefined fields when updating will not be cleared after editing', async function () {
         this.timeout(30000);
         let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid)
         await createTransaction(mint)
         let originalTransaction = (await getTransactions(mint))[0]
 
         let transactionUpdates = getTransactionUpdates(originalTransaction)
-        setAllFieldsUndefined(transactionUpdates);
+        setAllOptionalFieldsUndefined(transactionUpdates);
 
         await editTransactionWithUpdates(mint, transactionUpdates)
         let updatedTransaction = (await getTransactions(mint))[0]
@@ -125,11 +124,12 @@ function setAllFieldsEmpty(transactionUpdates) {
   transactionUpdates.date = ""
 }
 
-function setAllFieldsUndefined(transactionUpdates) {
+function setAllOptionalFieldsUndefined(transactionUpdates) {
   transactionUpdates.merchant = undefined
   transactionUpdates.category = undefined
   transactionUpdates.categoryId = undefined
-  transactionUpdates.date = undefined
+  // Date is a required field
+  transactionUpdates.date = ""
 }
 
 function formatDate(currentYearStyledDate) {

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -10,9 +10,9 @@ try {
 }
 
 if (config) {
-  describe('pepper-mint', function () {
-    describe('handles editing transactions', function () {
-      it('verifies fields have changed after editing', async function () {
+  describe('pepper-mint', function() {
+    describe('handles editing transactions', function() {
+      it('verifies fields have changed after editing', async function() {
         this.timeout(30000);
         let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid);
         await createTransaction(mint);
@@ -26,7 +26,7 @@ if (config) {
 
         await doAssertionsWithUpdates(updatedTransaction, transactionUpdates);
       });
-      it('verifies undefined fields when updating will not be cleared after editing', async function () {
+      it('verifies undefined fields when updating will not be cleared after editing', async function() {
         this.timeout(30000);
         let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid);
         await createTransaction(mint);
@@ -42,7 +42,7 @@ if (config) {
 
         await doAssertions(updatedTransaction, originalTransaction);
       });
-      it('verifies empty fields when updating will not be cleared after editing', async function () {
+      it('verifies empty fields when updating will not be cleared after editing', async function() {
         this.timeout(30000);
         let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid);
         await createTransaction(mint);

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -13,6 +13,7 @@ try {
 describe('pepper-mint', function () {
   describe('handles editing transactions', function () {
     it('verifies fields have changed after editing', async function () {
+      this.timeout(30000);
       let mint = await PepperMint(config.username, config.password, config.ius_session, config.thx_guid)
       await createTransaction(mint)
       let transactions = await getTransactions(mint)

--- a/test/integration-test.js
+++ b/test/integration-test.js
@@ -82,7 +82,7 @@ function createTransaction(mint) {
         amount: 1.23,
         date: "05/04/2010",
         merchant: "Test Merchant Name",
-        note: "This is a test transaction"
+        note: "This is a test transaction",
     };
     return mint.createTransaction(createRequest);
 }
@@ -90,10 +90,10 @@ function createTransaction(mint) {
 function getTransactions(mint) {
     let getTransactionsRequest = {
         query: [
-            "Test Merchant Name"
+            "Test Merchant Name",
         ],
         startDate: new Date(2010, 4),
-        endDate: new Date(2010, 6)
+        endDate: new Date(2010, 6),
     };
     return mint.getTransactions(getTransactionsRequest);
 }
@@ -108,7 +108,7 @@ function getTransactionUpdates(originalTransaction) {
         merchant: "New Test Merchant Name",
         category: "Vacation",
         categoryId: 1504,
-        date: "05/05/2010"
+        date: "05/05/2010",
     };
 }
 


### PR DESCRIPTION
The 'txnedit' task is able to update all properties of a transaction
including notes, tags, etc. It is also compatible with all fields
which can be submitted with the 'simpleEdit' task.


Additionally I'd like to point out that with your args schema this should all be compatible. All of the field names are the same for both types of tasks. The 'simpleEdit' task seems to be used when you edit a transaction from the "Transactions" page on mint directly in the list of transactions. If you select a transaction in the transaction list and click on the "Edit details" tab just below the row, it expands the transaction and allows you to edit more details of the transaction. Clicking "Update" then posts the transaction update using the 'txnedit' task.

Let me know if you have any questions and I'd be happy to discuss this PR in more detail. I plan on updating the schema further to have explicit support for things like notes and tags if that's alright with you. However, for now I'd just like to make this small, nonbreaking change that will allow for future additions to the schema. Thanks!