### PR TITLE
Update Chromedriver Version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -177,7 +177,7 @@
       "dev": true
     },
     "chromedriver": {
-      "version": "2.40.0",
+      "version": "76.0.0",
       "resolved": "https://registry.npmjs.org/chromedriver/-/chromedriver-2.40.0.tgz",
       "integrity": "sha512-ewvRQ1HMk0vpFSWYCk5hKDoEz5QMPplx5w3C6/Me+03y1imr67l3Hxl9U0jn3mu2N7+c7BoC7JtNW6HzbRAwDQ==",
       "requires": {

--- a/package.json
+++ b/package.json
@@ -1,34 +1,34 @@
 {
-    "name": "pepper-mint",
-    "version": "2.1.2",
-    "description": "An unofficial API for mint.com",
-    "main": "index.js",
-    "scripts": {
-        "test": "mocha"
-    },
-    "repository": {
-        "type": "git",
-        "url": "http://github.com/dhleong/pepper-mint"
-    },
-    "keywords": [
-        "mint.com",
-        "mint",
-        "api"
-    ],
-    "author": "Daniel Leong <me@dhleong.net>",
-    "license": "ISC",
-    "bugs": {
-        "url": "https://github.com/dhleong/pepper-mint/issues"
-    },
-    "homepage": "https://github.com/dhleong/pepper-mint",
-    "dependencies": {
-        "version": "76.0.0",
-        "q": "^1.5.1",
-        "request": "^2.88.0",
-        "selenium-webdriver": "^3.6.0"
-    },
-    "devDependencies": {
-        "chai": "^4.2.0",
-        "mocha": "^6.1.4"
-    }
+  "name": "pepper-mint",
+  "version": "2.1.2",
+  "description": "An unofficial API for mint.com",
+  "main": "index.js",
+  "scripts": {
+    "test": "mocha"
+  },
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/dhleong/pepper-mint"
+  },
+  "keywords": [
+    "mint.com",
+    "mint",
+    "api"
+  ],
+  "author": "Daniel Leong <me@dhleong.net>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/dhleong/pepper-mint/issues"
+  },
+  "homepage": "https://github.com/dhleong/pepper-mint",
+  "dependencies": {
+    "chromedriver": "^2.40.0",
+    "q": "^1.5.1",
+    "request": "^2.88.0",
+    "selenium-webdriver": "^3.6.0"
+  },
+  "devDependencies": {
+    "chai": "^4.2.0",
+    "mocha": "^6.1.4"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/dhleong/pepper-mint",
   "dependencies": {
-    "chromedriver": "^2.40.0",
+    "chromedriver": "^76.0.0",
     "q": "^1.5.1",
     "request": "^2.88.0",
     "selenium-webdriver": "^3.6.0"

--- a/package.json
+++ b/package.json
@@ -1,34 +1,34 @@
 {
-  "name": "pepper-mint",
-  "version": "2.1.2",
-  "description": "An unofficial API for mint.com",
-  "main": "index.js",
-  "scripts": {
-    "test": "mocha"
-  },
-  "repository": {
-    "type": "git",
-    "url": "http://github.com/dhleong/pepper-mint"
-  },
-  "keywords": [
-    "mint.com",
-    "mint",
-    "api"
-  ],
-  "author": "Daniel Leong <me@dhleong.net>",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/dhleong/pepper-mint/issues"
-  },
-  "homepage": "https://github.com/dhleong/pepper-mint",
-  "dependencies": {
-    "chromedriver": "^2.40.0",
-    "q": "^1.5.1",
-    "request": "^2.88.0",
-    "selenium-webdriver": "^3.6.0"
-  },
-  "devDependencies": {
-    "chai": "^4.2.0",
-    "mocha": "^6.1.4"
-  }
+    "name": "pepper-mint",
+    "version": "2.1.2",
+    "description": "An unofficial API for mint.com",
+    "main": "index.js",
+    "scripts": {
+        "test": "mocha"
+    },
+    "repository": {
+        "type": "git",
+        "url": "http://github.com/dhleong/pepper-mint"
+    },
+    "keywords": [
+        "mint.com",
+        "mint",
+        "api"
+    ],
+    "author": "Daniel Leong <me@dhleong.net>",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/dhleong/pepper-mint/issues"
+    },
+    "homepage": "https://github.com/dhleong/pepper-mint",
+    "dependencies": {
+        "version": "76.0.0",
+        "q": "^1.5.1",
+        "request": "^2.88.0",
+        "selenium-webdriver": "^3.6.0"
+    },
+    "devDependencies": {
+        "chai": "^4.2.0",
+        "mocha": "^6.1.4"
+    }
 }


### PR DESCRIPTION
The Chromedriver version is outdated and causes Peppermint to fail if you have the latest version of Chrome Installed.

This PR updates Chromedriver to the latest version.